### PR TITLE
Add road building and stone resource

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Ant Simulation - click to add food</title>
+  <title>Ant Simulation - click: food / shift+click: stone</title>
   <style>html,body{margin:0;padding:0;overflow:hidden;background:#111}canvas{display:block}</style>
 </head>
 <body>
@@ -25,7 +25,7 @@ const CONFIG={
   /* nest forces */
   NEST_ATTRACTION_IDLE:0.02,   // weaker pull
   NEST_ATTRACTION_RETURN:0.08,
-  NEST_REPEL_IDLE:0.01,        // idle ants gently pushed out
+  NEST_REPEL_IDLE:0.02,        // idle ants gently pushed out
   NEST_REPEL_EXPLORING:0.03,
   /* trails */
   TRAIL_FADE:0.18,
@@ -37,6 +37,15 @@ const CONFIG={
   /* food */
   FOOD_PILES:25,
   FOOD_PILE_CAPACITY:120,
+  /* road materials */
+  STONE_PILES:12,
+  STONE_PILE_CAPACITY:80,
+  /* roads */
+  ROAD_CELL:6,
+  ROAD_DECAY:0.985,
+  ROAD_DEPOSIT:0.4,
+  ROAD_FOLLOW:0.2,
+  POST_RETURN_WANDER:400,
   FOOD_PICKUP_RADIUS:4,
   FOOD_DETECT_RADIUS:38,
   FOOD_BASE_RADIUS:18,
@@ -47,7 +56,10 @@ const CONFIG={
 /* ============ CANVAS ============ */
 const canvas=document.getElementById('antCanvas');
 const ctx=canvas.getContext('2d');
-function resize(){canvas.width=innerWidth;canvas.height=innerHeight;}resize();addEventListener('resize',resize);
+let roadW,roadH,roads;
+function initRoads(){roadW=Math.ceil(canvas.width/CONFIG.ROAD_CELL);roadH=Math.ceil(canvas.height/CONFIG.ROAD_CELL);roads=new Float32Array(roadW*roadH);}
+function resize(){canvas.width=innerWidth;canvas.height=innerHeight;initRoads();}
+resize();addEventListener('resize',resize);
 
 /* ============ TORUS UTILS ============ */
 const wrapAngle=a=>{while(a> Math.PI)a-=Math.PI*2;while(a<-Math.PI)a+=Math.PI*2;return a};
@@ -56,6 +68,12 @@ function dxT(ax,bx){let d=bx-ax,w=canvas.width; if(d>w/2)d-=w; else if(d<-w/2)d+
 function dyT(ay,by){let d=by-ay,h=canvas.height;if(d>h/2)d-=h; else if(d<-h/2)d+=h; return d;}
 const dist2T=(ax,ay,bx,by)=>{const dx=dxT(ax,bx),dy=dyT(ay,by);return dx*dx+dy*dy;};
 
+/* ============ ROAD UTILS ============ */
+function roadIdx(x,y){const xi=Math.floor(mod(x,canvas.width)/CONFIG.ROAD_CELL),yi=Math.floor(mod(y,canvas.height)/CONFIG.ROAD_CELL);return (xi+yi*roadW)%roads.length;}
+function depositRoad(x,y,a){const i=roadIdx(x,y);roads[i]=Math.min(1,roads[i]+a);}
+function senseRoad(x,y){const xi=Math.floor(mod(x,canvas.width)/CONFIG.ROAD_CELL),yi=Math.floor(mod(y,canvas.height)/CONFIG.ROAD_CELL);let best=0,dir=0;for(let dx=-1;dx<=1;dx++)for(let dy=-1;dy<=1;dy++){if(!dx&&!dy)continue;const nx=(xi+dx+roadW)%roadW,ny=(yi+dy+roadH)%roadH,v=roads[nx+ny*roadW];if(v>best){best=v;dir=Math.atan2(dy,dx);}}return{best,dir};}
+function decayRoads(){for(let i=0;i<roads.length;i++)roads[i]*=CONFIG.ROAD_DECAY;}
+
 /* ============ CLASSES ============ */
 class Faction{constructor(n,c,j){Object.assign(this,{n,c,j})}}
 class Nest{
@@ -63,16 +81,16 @@ class Nest{
   draw(){ctx.fillStyle=this.f.c;ctx.beginPath();ctx.arc(this.x,this.y,6,0,Math.PI*2);ctx.fill();ctx.fillStyle="#fff";ctx.font="10px monospace";ctx.fillText(this.stock,this.x+8,this.y+3);}
 }
 
-class FoodPile{
-  constructor(x,y,cap){this.x=x;this.y=y;this.chunks=[];const R=CONFIG.FOOD_BASE_RADIUS;while(this.chunks.length<cap){const r=Math.sqrt(Math.random())*R,t=Math.random()*Math.PI*2;this.chunks.push({ox:Math.round(r*Math.cos(t)),oy:Math.round(r*Math.sin(t))});}}
+class ResourcePile{
+  constructor(x,y,cap,type,color){Object.assign(this,{x,y,type,color});this.chunks=[];const R=CONFIG.FOOD_BASE_RADIUS;while(this.chunks.length<cap){const r=Math.sqrt(Math.random())*R,t=Math.random()*Math.PI*2;this.chunks.push({ox:Math.round(r*Math.cos(t)),oy:Math.round(r*Math.sin(t))});}}
   get empty(){return this.chunks.length===0}
   takeNear(x,y,rad){if(this.empty)return false;const r2=rad*rad;for(let i=0;i<this.chunks.length;i++){const cx=mod(this.x+this.chunks[i].ox,canvas.width),cy=mod(this.y+this.chunks[i].oy,canvas.height);if(dist2T(x,y,cx,cy)<=r2){this.chunks.splice(i,1);return true;}}return false;}
   detectChunk(x,y,rad){const r2=rad*rad;for(const ch of this.chunks){const cx=mod(this.x+ch.ox,canvas.width),cy=mod(this.y+ch.oy,canvas.height);if(dist2T(x,y,cx,cy)<=r2)return {cx,cy};}return null;}
-  draw(){ctx.fillStyle="rgba(255,215,0,0.9)";for(const ch of this.chunks){ctx.fillRect(mod(this.x+ch.ox,canvas.width),mod(this.y+ch.oy,canvas.height),1,1);} }
+  draw(){ctx.fillStyle=this.color;for(const ch of this.chunks){ctx.fillRect(mod(this.x+ch.ox,canvas.width),mod(this.y+ch.oy,canvas.height),1,1);} }
 }
 
 class Ant{
-  constructor(x,y,f,nest){Object.assign(this,{x,y,f,nest});this.speed=CONFIG.MIN_SPEED+Math.random()*(CONFIG.MAX_SPEED-CONFIG.MIN_SPEED);this.angle=Math.random()*Math.PI*2;this.turnJitter=(0.8+Math.random()*0.4)*this.f.j;this.state='idle';this.ticks=0;this.carrying=false;this.scanCountdown=Math.floor(Math.random()*CONFIG.HEAVY_SCAN_INTERVAL);} // spread load
+  constructor(x,y,f,nest){Object.assign(this,{x,y,f,nest});this.speed=CONFIG.MIN_SPEED+Math.random()*(CONFIG.MAX_SPEED-CONFIG.MIN_SPEED);this.angle=Math.random()*Math.PI*2;this.turnJitter=(0.8+Math.random()*0.4)*this.f.j;this.state='idle';this.ticks=0;this.carrying=null;this.scanCountdown=Math.floor(Math.random()*CONFIG.HEAVY_SCAN_INTERVAL);} // spread load
   heavyScan(){this.scanCountdown=CONFIG.HEAVY_SCAN_INTERVAL;return true;}
   update(ants,piles,explRatio){if(--this.scanCountdown<0)this.heavyScan();if(this.state==='idle'&&explRatio<CONFIG.EXPLORE_MAX_RATIO&&Math.random()<CONFIG.EXPLORE_CHANCE){this.state='explore';this.ticks=Math.floor(CONFIG.EXPLORE_TIME_MIN+Math.random()*(CONFIG.EXPLORE_TIME_MAX-CONFIG.EXPLORE_TIME_MIN));}
 
@@ -89,13 +107,16 @@ class Ant{
     if(this.state==='explore'){
       this.attractNest(-CONFIG.NEST_REPEL_EXPLORING); // stronger repel
       if(this.scanCountdown===0){for(const p of piles){if(p.empty)continue; if(dist2T(this.x,this.y,p.x,p.y)>(CONFIG.FOOD_DETECT_RADIUS+CONFIG.FOOD_BASE_RADIUS)**2)continue; const tgt=p.detectChunk(this.x,this.y,CONFIG.FOOD_DETECT_RADIUS); if(tgt){const desired=Math.atan2(dyT(this.y,tgt.cy),dxT(this.x,tgt.cx));this.angle+=wrapAngle(desired-this.angle)*0.18; break;}}}
-      if(this.scanCountdown===0){for(const p of piles){if(p.takeNear(this.x,this.y,CONFIG.FOOD_PICKUP_RADIUS)){this.carrying=true;this.state='return';break;}}}
+      if(this.scanCountdown===0){for(const p of piles){if(p.takeNear(this.x,this.y,CONFIG.FOOD_PICKUP_RADIUS)){this.carrying=p.type;this.state='return';break;}}}
       if(--this.ticks<=0&&this.state==='explore')this.state='return';
     }
     if(this.state==='return'){
       this.attractNest(CONFIG.NEST_ATTRACTION_RETURN);
-      if(dist2T(this.x,this.y,this.nest.x,this.nest.y)<400){if(this.carrying){this.nest.stock++;this.carrying=false;}this.state='idle';}
+      if(dist2T(this.x,this.y,this.nest.x,this.nest.y)<400){if(this.carrying==='food'){this.nest.stock++;}this.carrying=null;this.state='explore';this.ticks=CONFIG.POST_RETURN_WANDER;}
     }
+
+    if(this.carrying==='stone') depositRoad(this.x,this.y,CONFIG.ROAD_DEPOSIT);
+    else if(this.scanCountdown===0){const s=senseRoad(this.x,this.y);if(s.best>0.05)this.angle+=wrapAngle(s.dir-this.angle)*CONFIG.ROAD_FOLLOW;}
 
     /* ==== move ==== */
     this.angle+=(Math.random()*2-1)*this.turnJitter;
@@ -103,16 +124,16 @@ class Ant{
     this.y=mod(this.y+Math.sin(this.angle)*this.speed,canvas.height);
   }
   attractNest(k){const dx=dxT(this.x,this.nest.x),dy=dyT(this.y,this.nest.y);this.angle+=wrapAngle(Math.atan2(dy,dx)-this.angle)*k;}
-  draw(){ctx.fillStyle=this.f.c;ctx.beginPath();ctx.arc(this.x,this.y,this.carrying?3:2,0,Math.PI*2);ctx.fill();if(this.carrying){ctx.fillStyle="#fff";ctx.fillRect(this.x,this.y,1,1);}}
+  draw(){ctx.fillStyle=this.f.c;ctx.beginPath();ctx.arc(this.x,this.y,this.carrying?3:2,0,Math.PI*2);ctx.fill();if(this.carrying==='food'){ctx.fillStyle="#fff";ctx.fillRect(this.x,this.y,1,1);}if(this.carrying==='stone'){ctx.fillStyle="#aaa";ctx.fillRect(this.x-1,this.y-1,3,3);}}
 }
 
 class Sim{
-  constructor(){this.factions=[new Faction('Red','rgba(255,80,80,0.9)',CONFIG.RANDOM_TURN_JITTER*1.4),new Faction('Green','rgba(80,255,80,0.9)',CONFIG.RANDOM_TURN_JITTER*0.8),new Faction('Blue','rgba(80,80,255,0.9)',CONFIG.RANDOM_TURN_JITTER*1.2)];this.nests=this.buildNests();this.ants=this.buildAnts();this.piles=this.buildFood();}
+  constructor(){this.factions=[new Faction('Red','rgba(255,80,80,0.9)',CONFIG.RANDOM_TURN_JITTER*1.4),new Faction('Green','rgba(80,255,80,0.9)',CONFIG.RANDOM_TURN_JITTER*0.8),new Faction('Blue','rgba(80,80,255,0.9)',CONFIG.RANDOM_TURN_JITTER*1.2)];this.nests=this.buildNests();this.ants=this.buildAnts();this.piles=this.buildPiles();}
   buildNests(){const arr=[],m=110;this.factions.forEach((f,i)=>{const a=i/this.factions.length*Math.PI*2;arr.push(new Nest(canvas.width/2+(canvas.width/2-m)*Math.cos(a),canvas.height/2+(canvas.height/2-m)*Math.sin(a),f));});return arr;}
   buildAnts(){const a=[];for(let i=0;i<CONFIG.ANT_COUNT;i++){const f=this.factions[i%this.factions.length],n=this.nests.find(n=>n.f===f),off=()=> (Math.random()-0.5)*30;a.push(new Ant(n.x+off(),n.y+off(),f,n));}return a;}
-  buildFood(){const arr=[];for(let i=0;i<CONFIG.FOOD_PILES;i++)arr.push(new FoodPile(Math.random()*canvas.width,Math.random()*canvas.height,CONFIG.FOOD_PILE_CAPACITY));return arr;}
-  update(){const explorers=this.ants.filter(a=>a.state==='explore').length,ratio=explorers/this.ants.length;this.ants.forEach(a=>a.update(this.ants,this.piles,ratio));this.piles=this.piles.filter(p=>!p.empty);if(this.piles.length<CONFIG.FOOD_PILES*0.8)this.piles.push(new FoodPile(Math.random()*canvas.width,Math.random()*canvas.height,CONFIG.FOOD_PILE_CAPACITY));}
-  draw(){ctx.fillStyle=`rgba(17,17,17,${CONFIG.TRAIL_FADE})`;ctx.fillRect(0,0,canvas.width,canvas.height);this.piles.forEach(p=>p.draw());this.nests.forEach(n=>n.draw());this.ants.forEach(a=>a.draw());}
+  buildPiles(){const arr=[];for(let i=0;i<CONFIG.FOOD_PILES;i++)arr.push(new ResourcePile(Math.random()*canvas.width,Math.random()*canvas.height,CONFIG.FOOD_PILE_CAPACITY,'food','rgba(255,215,0,0.9)'));for(let i=0;i<CONFIG.STONE_PILES;i++)arr.push(new ResourcePile(Math.random()*canvas.width,Math.random()*canvas.height,CONFIG.STONE_PILE_CAPACITY,'stone','rgba(200,200,200,0.9)'));return arr;}
+  update(){const explorers=this.ants.filter(a=>a.state==='explore').length,ratio=explorers/this.ants.length;decayRoads();this.ants.forEach(a=>a.update(this.ants,this.piles,ratio));this.piles=this.piles.filter(p=>!p.empty);const fCount=this.piles.filter(p=>p.type==='food').length,sCount=this.piles.filter(p=>p.type==='stone').length;if(fCount<CONFIG.FOOD_PILES*0.8)this.piles.push(new ResourcePile(Math.random()*canvas.width,Math.random()*canvas.height,CONFIG.FOOD_PILE_CAPACITY,'food','rgba(255,215,0,0.9)'));if(sCount<CONFIG.STONE_PILES*0.8)this.piles.push(new ResourcePile(Math.random()*canvas.width,Math.random()*canvas.height,CONFIG.STONE_PILE_CAPACITY,'stone','rgba(200,200,200,0.9)'));}
+  draw(){ctx.fillStyle=`rgba(17,17,17,${CONFIG.TRAIL_FADE})`;ctx.fillRect(0,0,canvas.width,canvas.height);for(let i=0;i<roads.length;i++){const v=roads[i];if(v>0.05){const x=(i%roadW)*CONFIG.ROAD_CELL,y=Math.floor(i/roadW)*CONFIG.ROAD_CELL;ctx.fillStyle=`rgba(100,100,100,${v})`;ctx.fillRect(x,y,CONFIG.ROAD_CELL,CONFIG.ROAD_CELL);}}this.piles.forEach(p=>p.draw());this.nests.forEach(n=>n.draw());this.ants.forEach(a=>a.draw());}
 }
 
 /* ============ MAIN LOOP ============ */
@@ -121,7 +142,8 @@ canvas.addEventListener("click",e=>{
   const r=canvas.getBoundingClientRect();
   const x=e.clientX-r.left;
   const y=e.clientY-r.top;
-  sim.piles.push(new FoodPile(x,y,CONFIG.FOOD_PILE_CAPACITY));
+  if(e.shiftKey) sim.piles.push(new ResourcePile(x,y,CONFIG.STONE_PILE_CAPACITY,'stone','rgba(200,200,200,0.9)'));
+  else sim.piles.push(new ResourcePile(x,y,CONFIG.FOOD_PILE_CAPACITY,'food','rgba(255,215,0,0.9)'));
 });
 let STEPS_PER_FRAME=5; // we kept some warp – feel free to change with +/- keys
 addEventListener('keydown',e=>{if(e.key==='+')STEPS_PER_FRAME=Math.min(100,STEPS_PER_FRAME*2);if(e.key==='-')STEPS_PER_FRAME=Math.max(1,STEPS_PER_FRAME/2);});


### PR DESCRIPTION
## Summary
- increase nest repel and update window title
- add stone resource piles and road infrastructure grid
- allow ants to gather stone and build roads that other ants follow
- draw roads on the canvas and support shift-click to add stone

## Testing
- `node --check index.html` *(fails: unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_e_6871ad9812a88321986f28ac9912d48b